### PR TITLE
Set up VM output directory sharing

### DIFF
--- a/run/README.md
+++ b/run/README.md
@@ -24,6 +24,14 @@ To start a container with the built image and the required volume mappings, use 
 
 This script mounts the main directory and the challenge source directory into the container, installs some programs, and opens an interactive shell.
 
+Files created in `../vm_shared` on the host are available inside the container at
+`/tmp/output`.  The VM started by `run_vng.sh` exposes this directory as a 9p
+share using the tag `vmshare`.  Inside the VM you can mount it with:
+
+```sh
+mount -t 9p -o trans=virtio,version=9p2000.L vmshare /tmp/output
+```
+
 ---
 
 ## 3. Compiling the Kernel

--- a/run/launch.sh
+++ b/run/launch.sh
@@ -4,16 +4,22 @@
 
 # lightweight env for running symfit
 # map local folders and compile
+# Name of the Docker image to run
 DKIMG="system-mode-sym"
+
+# Create a folder on the host that will be shared with the VM
+HOST_SHARED_DIR="$PWD/../vm_shared"
+mkdir -p "$HOST_SHARED_DIR"
 # DKIMG="sym_dev"
 
 docker run --rm -ti --ulimit core=0 \
-	    -e "SYMCC_MEMORY_INPUT=1" \
-            -v $PWD/..:/workdir        \
+            -e "SYMCC_MEMORY_INPUT=1" \
+             -v $PWD/..:/workdir        \
+             -v "$HOST_SHARED_DIR":/tmp/output \
             $DKIMG \
-	    /bin/bash -lc "\
-	    set -eux; \
-	    mkdir -p /tmp/output; \
+            /bin/bash -lc "\
+            set -eux; \
+            mkdir -p /tmp/output; \
 	    apt-get install -y nano xxd; \
 	    gcc ./kernel_syscall_test.c -o kernel_syscall_test; \
 	    exec bash"

--- a/run/run_vng.sh
+++ b/run/run_vng.sh
@@ -25,6 +25,9 @@
     -name virtme-ng -m 1G \
     -fsdev local,id=virtfs5,path=/,security_model=none,readonly=on,multidevs=remap \
     -device virtio-9p-pci,fsdev=virtfs5,mount_tag=/dev/root \
+    # expose /tmp/output from the container to the VM as tag "vmshare"
+    -fsdev local,id=virtfs_shared,path=/tmp/output,security_model=none,multidevs=remap \
+    -device virtio-9p-pci,fsdev=virtfs_shared,mount_tag=vmshare \
     -device i6300esb,id=watchdog0 -machine q35 -parallel none -net none \
     -echr 1 -chardev file,path=/proc/self/fd/2,id=dmesg \
     -device virtio-serial-pci -device virtconsole,chardev=dmesg \


### PR DESCRIPTION
## Summary
- share host `vm_shared` folder with the container at `/tmp/output`
- expose `/tmp/output` to the VM via 9p in `run_vng.sh`
- update README with mount instructions

## Testing
- `make help`

------
https://chatgpt.com/codex/tasks/task_e_6855cd7a651c832abb89e6f451f38fe6